### PR TITLE
SQL Studio Java to C# Changes

### DIFF
--- a/src/chapters/sql-part1/studio.rst
+++ b/src/chapters/sql-part1/studio.rst
@@ -5,7 +5,7 @@ Studio: Movie SQLs
 
 In this studio, you will use space in *MySQL Workbench* to practice writing SQL
 queries to retrieve or modify information stored in an established database.
-You will also explore the parallels between Java objects and database tables.
+You will also explore the parallels between C# objects and database tables.
 
 Walkthrough
 -----------
@@ -32,13 +32,13 @@ columns (``INTEGER``, ``VARCHAR``, ``DATE``, etc.), then go ahead and write (or
 type) the SQL statement to create this table.
 
 As you consider which data types to use for your ``movies`` columns, you might
-find yourself thinking, *If this were a property of a Java object, what data
+find yourself thinking, *If this were a property of a C# object, what data
 type would I use?*
 
-For example, if the ``movie`` object has a ``title`` and a ``director`` field,
+For example, if the ``Movie`` object has a ``Title`` and a ``Director`` property,
 you would expect both of these data types to be ``String``. Similarly, the year
 the movie was released would be stored as an integer. This conceptual overlap
-between databases and Java objects is very useful, and we will explore this
+between databases and C# objects is very useful, and we will explore this
 further in the class on *Object-Relational Mapping* (ORM).
 
 Here's how our ``movies`` table could be created:
@@ -62,9 +62,9 @@ Take a moment to discuss with a partner:
 Directors Table
 ^^^^^^^^^^^^^^^
 
-Next, let's consider the properties we'd want for a ``director`` object in
-Java. These could include a ``first_name``, a ``last_name``, and maybe the
-``country`` where the director was born.
+Next, let's consider the properties we'd want for a ``Director`` object in
+C#. These could include a ``FirstName``, a ``LastName``, and maybe the
+``Country`` where the director was born.
 
 Once we identify the data types for these properties, we can write the SQL
 command to create the ``directors`` table. Also, we should include a


### PR DESCRIPTION
Replaced Java with C# references and updated Java style naming of properties to C# naming conventions.

Just a note:  I know the naming conventions used in this chapter are standard for MySQL.  But it will make it "slightly" harder to map the properties in C# since the names won't match.  But maybe that is the intention to teaching mapping to different standards in an ORM.